### PR TITLE
Feat/login info

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -175,18 +175,21 @@ export type Database = {
       }
       language: {
         Row: {
+          created_at: string
           id: number
           language_img_url: string
           language_name: string
           status: boolean
         }
         Insert: {
+          created_at?: string
           id?: number
-          language_img_url: string
-          language_name: string
+          language_img_url?: string
+          language_name?: string
           status?: boolean
         }
         Update: {
+          created_at?: string
           id?: number
           language_img_url?: string
           language_name?: string
@@ -257,6 +260,41 @@ export type Database = {
           {
             foreignKeyName: "Messages_sender_id_fkey"
             columns: ["sender_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      notifications: {
+        Row: {
+          created_at: string | null
+          id: number
+          is_read: boolean | null
+          message: string
+          title: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: number
+          is_read?: boolean | null
+          message: string
+          title: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: number
+          is_read?: boolean | null
+          message?: string
+          title?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_user"
+            columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "user_info"
             referencedColumns: ["id"]
@@ -470,21 +508,21 @@ export type Database = {
           is_deleted: boolean
           learn_language: string | null
           my_language: string | null
-          nickname: string | null
+          nickname: string
           profile_url: string
           state_msg: string
         }
         Insert: {
           created_at?: string
-          email: string
+          email?: string
           id?: string
           is_blocked?: boolean
           is_deleted?: boolean
           learn_language?: string | null
           my_language?: string | null
-          nickname?: string | null
-          profile_url: string
-          state_msg: string
+          nickname?: string
+          profile_url?: string
+          state_msg?: string
         }
         Update: {
           created_at?: string
@@ -494,26 +532,11 @@ export type Database = {
           is_deleted?: boolean
           learn_language?: string | null
           my_language?: string | null
-          nickname?: string | null
+          nickname?: string
           profile_url?: string
           state_msg?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "user_info_learn_language_fkey"
-            columns: ["learn_language"]
-            isOneToOne: false
-            referencedRelation: "language"
-            referencedColumns: ["language_name"]
-          },
-          {
-            foreignKeyName: "user_info_my_language_fkey"
-            columns: ["my_language"]
-            isOneToOne: false
-            referencedRelation: "language"
-            referencedColumns: ["language_name"]
-          },
-        ]
+        Relationships: []
       }
     }
     Views: {

--- a/database.types.ts
+++ b/database.types.ts
@@ -1,635 +1,658 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   public: {
     Tables: {
       answers: {
         Row: {
-          content: string;
-          created_at: string;
-          id: number;
-          is_correct: boolean | null;
-          question_id: number;
-          user_id: string;
-        };
+          content: string
+          created_at: string
+          id: number
+          is_correct: boolean | null
+          question_id: number
+          user_id: string
+        }
         Insert: {
-          content: string;
-          created_at?: string;
-          id: number;
-          is_correct?: boolean | null;
-          question_id: number;
-          user_id?: string;
-        };
+          content: string
+          created_at?: string
+          id: number
+          is_correct?: boolean | null
+          question_id: number
+          user_id?: string
+        }
         Update: {
-          content?: string;
-          created_at?: string;
-          id?: number;
-          is_correct?: boolean | null;
-          question_id?: number;
-          user_id?: string;
-        };
+          content?: string
+          created_at?: string
+          id?: number
+          is_correct?: boolean | null
+          question_id?: number
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "answers_question_id_fkey";
-            columns: ["question_id"];
-            isOneToOne: false;
-            referencedRelation: "questions";
-            referencedColumns: ["id"];
+            foreignKeyName: "answers_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "answers_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "answers_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       block: {
         Row: {
-          created_at: string | null;
-          id: number;
-          reason: string;
-          reason_img_url: string | null;
-          target_id: string | null;
-          user_info_id: string | null;
-        };
+          created_at: string | null
+          id: number
+          reason: string
+          reason_img_url: string | null
+          target_id: string | null
+          user_info_id: string | null
+        }
         Insert: {
-          created_at?: string | null;
-          id?: number;
-          reason?: string;
-          reason_img_url?: string | null;
-          target_id?: string | null;
-          user_info_id?: string | null;
-        };
+          created_at?: string | null
+          id?: number
+          reason?: string
+          reason_img_url?: string | null
+          target_id?: string | null
+          user_info_id?: string | null
+        }
         Update: {
-          created_at?: string | null;
-          id?: number;
-          reason?: string;
-          reason_img_url?: string | null;
-          target_id?: string | null;
-          user_info_id?: string | null;
-        };
+          created_at?: string | null
+          id?: number
+          reason?: string
+          reason_img_url?: string | null
+          target_id?: string | null
+          user_info_id?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "block_target_id_fkey1";
-            columns: ["target_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
+            foreignKeyName: "block_target_id_fkey1"
+            columns: ["target_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "block_user_info_id_fkey";
-            columns: ["user_info_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "block_user_info_id_fkey"
+            columns: ["user_info_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       categories: {
         Row: {
-          depth: string | null;
-          id: number;
-          level: number | null;
-          name: string;
-        };
+          depth: string | null
+          id: number
+          level: number | null
+          name: string
+        }
         Insert: {
-          depth?: string | null;
-          id?: number;
-          level?: number | null;
-          name: string;
-        };
+          depth?: string | null
+          id?: number
+          level?: number | null
+          name: string
+        }
         Update: {
-          depth?: string | null;
-          id?: number;
-          level?: number | null;
-          name?: string;
-        };
-        Relationships: [];
-      };
+          depth?: string | null
+          id?: number
+          level?: number | null
+          name?: string
+        }
+        Relationships: []
+      }
       Conversations: {
         Row: {
-          created_at: string;
-          id: string;
-          last_message_id: string | null;
-          updated_at: string | null;
-        };
+          created_at: string
+          id: string
+          last_message_id: string | null
+          updated_at: string | null
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          last_message_id?: string | null;
-          updated_at?: string | null;
-        };
+          created_at?: string
+          id?: string
+          last_message_id?: string | null
+          updated_at?: string | null
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          last_message_id?: string | null;
-          updated_at?: string | null;
-        };
+          created_at?: string
+          id?: string
+          last_message_id?: string | null
+          updated_at?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "Conversations_last_message_id_fkey";
-            columns: ["last_message_id"];
-            isOneToOne: false;
-            referencedRelation: "Messages";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "Conversations_last_message_id_fkey"
+            columns: ["last_message_id"]
+            isOneToOne: false
+            referencedRelation: "Messages"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       faq: {
         Row: {
-          category: string | null;
-          comment: string;
-          content: string | null;
-          created_at: string;
-          id: string;
-          title: string | null;
-          user_id: string | null;
-        };
+          category: string | null
+          comment: string
+          content: string | null
+          created_at: string
+          id: string
+          title: string | null
+          user_id: string | null
+        }
         Insert: {
-          category?: string | null;
-          comment: string;
-          content?: string | null;
-          created_at?: string;
-          id?: string;
-          title?: string | null;
-          user_id?: string | null;
-        };
+          category?: string | null
+          comment: string
+          content?: string | null
+          created_at?: string
+          id?: string
+          title?: string | null
+          user_id?: string | null
+        }
         Update: {
-          category?: string | null;
-          comment?: string;
-          content?: string | null;
-          created_at?: string;
-          id?: string;
-          title?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [];
-      };
+          category?: string | null
+          comment?: string
+          content?: string | null
+          created_at?: string
+          id?: string
+          title?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       language: {
         Row: {
-          id: number;
-          language_img_url: string;
-          language_name: string;
-        };
+          id: number
+          language_img_url: string
+          language_name: string
+          status: boolean
+        }
         Insert: {
-          id?: number;
-          language_img_url: string;
-          language_name: string;
-        };
+          id?: number
+          language_img_url: string
+          language_name: string
+          status?: boolean
+        }
         Update: {
-          id?: number;
-          language_img_url?: string;
-          language_name?: string;
-        };
-        Relationships: [];
-      };
+          id?: number
+          language_img_url?: string
+          language_name?: string
+          status?: boolean
+        }
+        Relationships: []
+      }
       matches: {
         Row: {
-          created_at: string;
-          id: number;
-          learn_language: string | null;
-          match_id: string | null;
-          my_language: string | null;
-          room_id: string | null;
-          user_id: string | null;
-        };
+          created_at: string
+          id: number
+          learn_language: string | null
+          match_id: string | null
+          my_language: string | null
+          room_id: string | null
+          user_id: string | null
+        }
         Insert: {
-          created_at?: string;
-          id?: number;
-          learn_language?: string | null;
-          match_id?: string | null;
-          my_language?: string | null;
-          room_id?: string | null;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id?: number
+          learn_language?: string | null
+          match_id?: string | null
+          my_language?: string | null
+          room_id?: string | null
+          user_id?: string | null
+        }
         Update: {
-          created_at?: string;
-          id?: number;
-          learn_language?: string | null;
-          match_id?: string | null;
-          my_language?: string | null;
-          room_id?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          id?: number
+          learn_language?: string | null
+          match_id?: string | null
+          my_language?: string | null
+          room_id?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       Messages: {
         Row: {
-          content: string;
-          conversation_id: string;
-          created_at: string;
-          id: string;
-          sender_id: string;
-        };
+          content: string
+          conversation_id: string
+          created_at: string
+          id: string
+          sender_id: string
+        }
         Insert: {
-          content: string;
-          conversation_id?: string;
-          created_at?: string;
-          id?: string;
-          sender_id?: string;
-        };
+          content: string
+          conversation_id?: string
+          created_at?: string
+          id?: string
+          sender_id?: string
+        }
         Update: {
-          content?: string;
-          conversation_id?: string;
-          created_at?: string;
-          id?: string;
-          sender_id?: string;
-        };
+          content?: string
+          conversation_id?: string
+          created_at?: string
+          id?: string
+          sender_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "Messages_conversation_id_fkey";
-            columns: ["conversation_id"];
-            isOneToOne: false;
-            referencedRelation: "Conversations";
-            referencedColumns: ["id"];
+            foreignKeyName: "Messages_conversation_id_fkey"
+            columns: ["conversation_id"]
+            isOneToOne: false
+            referencedRelation: "Conversations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "Messages_sender_id_fkey";
-            columns: ["sender_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "Messages_sender_id_fkey"
+            columns: ["sender_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       Participants: {
         Row: {
-          conversation_id: string;
-          id: string;
-          joined_at: string;
-          user_id: string;
-        };
+          conversation_id: string
+          id: string
+          joined_at: string
+          user_id: string
+        }
         Insert: {
-          conversation_id?: string;
-          id?: string;
-          joined_at?: string;
-          user_id?: string;
-        };
+          conversation_id?: string
+          id?: string
+          joined_at?: string
+          user_id?: string
+        }
         Update: {
-          conversation_id?: string;
-          id?: string;
-          joined_at?: string;
-          user_id?: string;
-        };
+          conversation_id?: string
+          id?: string
+          joined_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "Participants_conversation_id_fkey";
-            columns: ["conversation_id"];
-            isOneToOne: false;
-            referencedRelation: "Conversations";
-            referencedColumns: ["id"];
+            foreignKeyName: "Participants_conversation_id_fkey"
+            columns: ["conversation_id"]
+            isOneToOne: false
+            referencedRelation: "Conversations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "Participants_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "Participants_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       questions: {
         Row: {
-          answer: string;
-          content: string;
-          created_at: string;
-          id: number;
-          language: string;
-          reason: string;
-          type: string;
-          wrong_answer: string;
-        };
+          answer: string
+          content: string
+          created_at: string
+          id: number
+          language: string
+          reason: string
+          type: string
+          wrong_answer: string
+        }
         Insert: {
-          answer: string;
-          content: string;
-          created_at?: string;
-          id?: number;
-          language: string;
-          reason: string;
-          type: string;
-          wrong_answer: string;
-        };
+          answer: string
+          content: string
+          created_at?: string
+          id?: number
+          language: string
+          reason: string
+          type: string
+          wrong_answer: string
+        }
         Update: {
-          answer?: string;
-          content?: string;
-          created_at?: string;
-          id?: number;
-          language?: string;
-          reason?: string;
-          type?: string;
-          wrong_answer?: string;
-        };
-        Relationships: [];
-      };
+          answer?: string
+          content?: string
+          created_at?: string
+          id?: number
+          language?: string
+          reason?: string
+          type?: string
+          wrong_answer?: string
+        }
+        Relationships: []
+      }
       review: {
         Row: {
-          created_at: string;
-          id: number;
-          level: number;
-          situation: string | null;
-          user_id: string | null;
-        };
+          created_at: string
+          id: number
+          level: number
+          situation: string | null
+          user_id: string | null
+        }
         Insert: {
-          created_at?: string;
-          id?: number;
-          level: number;
-          situation?: string | null;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id?: number
+          level: number
+          situation?: string | null
+          user_id?: string | null
+        }
         Update: {
-          created_at?: string;
-          id?: number;
-          level?: number;
-          situation?: string | null;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id?: number
+          level?: number
+          situation?: string | null
+          user_id?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "review_situation_fkey";
-            columns: ["situation"];
-            isOneToOne: false;
-            referencedRelation: "situation";
-            referencedColumns: ["situation"];
+            foreignKeyName: "review_situation_fkey"
+            columns: ["situation"]
+            isOneToOne: false
+            referencedRelation: "situation"
+            referencedColumns: ["situation"]
           },
           {
-            foreignKeyName: "review_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "review_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       situation: {
         Row: {
-          id: number;
-          level: number;
-          situation: string;
-        };
+          id: number
+          level: number
+          situation: string
+        }
         Insert: {
-          id?: number;
-          level: number;
-          situation: string;
-        };
+          id?: number
+          level: number
+          situation: string
+        }
         Update: {
-          id?: number;
-          level?: number;
-          situation?: string;
-        };
-        Relationships: [];
-      };
+          id?: number
+          level?: number
+          situation?: string
+        }
+        Relationships: []
+      }
       test_result: {
         Row: {
-          created_at: string;
-          id: number;
-          level: number;
-          situation: string;
-          user_id: string;
-        };
+          category_id: number | null
+          collect: number | null
+          created_at: string
+          id: number
+          total: number | null
+          user_id: string | null
+        }
         Insert: {
-          created_at?: string;
-          id?: number;
-          level?: number | null;
-          situation?: string | null;
-          user_id?: string | null;
-        };
+          category_id?: number | null
+          collect?: number | null
+          created_at?: string
+          id?: number
+          total?: number | null
+          user_id?: string | null
+        }
         Update: {
-          category_id?: number | null;
-          collect?: number | null;
-          created_at?: string;
-          id?: number;
-          total?: number | null;
-          user_id?: string | null;
-        };
-        Relationships: [];
-      };
+          category_id?: number | null
+          collect?: number | null
+          created_at?: string
+          id?: number
+          total?: number | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       user_answer: {
         Row: {
-          created_at: string | null;
-          id: number;
-          is_corrected: boolean;
-          is_reviewed: boolean;
-          question_id: number;
-          selected_answer: string;
-          user_id: string;
-        };
+          created_at: string | null
+          id: number
+          is_corrected: boolean
+          is_reviewed: boolean
+          question_id: number
+          selected_answer: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string | null;
-          id?: number;
-          is_corrected: boolean;
-          is_reviewed: boolean;
-          question_id: number;
-          selected_answer?: string;
-          user_id: string;
-        };
+          created_at?: string | null
+          id?: number
+          is_corrected: boolean
+          is_reviewed: boolean
+          question_id: number
+          selected_answer?: string
+          user_id: string
+        }
         Update: {
-          created_at?: string | null;
-          id?: number;
-          is_corrected?: boolean;
-          is_reviewed?: boolean;
-          question_id?: number;
-          selected_answer?: string;
-          user_id?: string;
-        };
+          created_at?: string | null
+          id?: number
+          is_corrected?: boolean
+          is_reviewed?: boolean
+          question_id?: number
+          selected_answer?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_answer_question_id_fkey";
-            columns: ["question_id"];
-            isOneToOne: false;
-            referencedRelation: "questions";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_answer_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "user_answer_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "user_info";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "user_answer_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_info"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       user_info: {
         Row: {
-          created_at: string;
-          email: string;
-          id: string;
-          is_blocked: boolean;
-          is_deleted: boolean;
-          learn_language: string;
-          my_language: string;
-          nickname: string;
-          profile_url: string;
-          state_msg: string;
-        };
+          created_at: string
+          email: string
+          id: string
+          is_blocked: boolean
+          is_deleted: boolean
+          learn_language: string | null
+          my_language: string | null
+          nickname: string | null
+          profile_url: string
+          state_msg: string
+        }
         Insert: {
-          created_at?: string;
-          email: string;
-          id?: string;
-          is_blocked?: boolean;
-          is_deleted?: boolean;
-          learn_language: string;
-          my_language?: string;
-          nickname?: string;
-          profile_url?: string;
-          state_msg?: string;
-        };
+          created_at?: string
+          email: string
+          id?: string
+          is_blocked?: boolean
+          is_deleted?: boolean
+          learn_language?: string | null
+          my_language?: string | null
+          nickname?: string | null
+          profile_url: string
+          state_msg: string
+        }
         Update: {
-          created_at?: string;
-          email?: string;
-          id?: string;
-          is_blocked?: boolean;
-          is_deleted?: boolean;
-          learn_language?: string;
-          my_language?: string;
-          nickname?: string;
-          profile_url?: string;
-          state_msg?: string;
-        };
+          created_at?: string
+          email?: string
+          id?: string
+          is_blocked?: boolean
+          is_deleted?: boolean
+          learn_language?: string | null
+          my_language?: string | null
+          nickname?: string | null
+          profile_url?: string
+          state_msg?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_info_learn_language_fkey";
-            columns: ["learn_language"];
-            isOneToOne: false;
-            referencedRelation: "language";
-            referencedColumns: ["language_name"];
+            foreignKeyName: "user_info_learn_language_fkey"
+            columns: ["learn_language"]
+            isOneToOne: false
+            referencedRelation: "language"
+            referencedColumns: ["language_name"]
           },
           {
-            foreignKeyName: "user_info_my_language_fkey";
-            columns: ["my_language"];
-            isOneToOne: false;
-            referencedRelation: "language";
-            referencedColumns: ["language_name"];
-          }
-        ];
-      };
-    };
+            foreignKeyName: "user_info_my_language_fkey"
+            columns: ["my_language"]
+            isOneToOne: false
+            referencedRelation: "language"
+            referencedColumns: ["language_name"]
+          },
+        ]
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       get_random_questions:
         | {
-            Args: Record<PropertyKey, never>;
+            Args: Record<PropertyKey, never>
             Returns: {
-              answer: string;
-              content: string;
-              created_at: string;
-              id: number;
-              language: string;
-              reason: string;
-              type: string;
-              wrong_answer: string;
-            }[];
+              answer: string
+              content: string
+              created_at: string
+              id: number
+              language: string
+              reason: string
+              type: string
+              wrong_answer: string
+            }[]
           }
         | {
             Args: {
-              language: string;
-              type: string;
-            };
+              language: string
+              type: string
+            }
             Returns: {
-              answer: string;
-              content: string;
-              created_at: string;
-              id: number;
-              language: string;
-              reason: string;
-              type: string;
-              wrong_answer: string;
-            }[];
-          };
-    };
+              answer: string
+              content: string
+              created_at: string
+              id: number
+              language: string
+              reason: string
+              type: string
+              wrong_answer: string
+            }[]
+          }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R;
+      Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-  ? (PublicSchema["Tables"] & PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R;
-    }
-    ? R
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I;
+      Insert: infer I
     }
     ? I
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I;
-    }
-    ? I
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U;
+      Update: infer U
     }
     ? U
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U;
-    }
-    ? U
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof Database },
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-  : never;
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof Database },
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof Database
   }
     ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
   ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-  ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-  : never;
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never

--- a/src/api/firstSetting/fetchLanguageName.ts
+++ b/src/api/firstSetting/fetchLanguageName.ts
@@ -1,0 +1,15 @@
+import { createClient } from "@/utils/supabase/client";
+import { Tables } from "../../../database.types";
+
+type LanguageName = { language_name: string };
+const supabase = createClient();
+
+// 'language'테이블에서 'language_name'만 가져오는 함수
+export const fetchLanguageName = async (): Promise<LanguageName[]> => {
+  const { data, error } = await supabase.from("language").select("language_name");
+  console.log("지원언어", data);
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data;
+};

--- a/src/app/(mobile)/challenge/grammar/wrongAnswerNote/page.tsx
+++ b/src/app/(mobile)/challenge/grammar/wrongAnswerNote/page.tsx
@@ -17,7 +17,7 @@ const WrongGrammarPage = async () => {
 
   return (
     <div>
-      <h1>단어 오답노트</h1>
+      <h1>문법 오답노트</h1>
       <GrammarList userId={userId} />
     </div>
   );

--- a/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { createClient } from "@/utils/supabase/server";
+
+const learnLanguages = ["영어", "일본어", "스페인어", "프랑스어"];
+
+export default function SetLearnLanguage() {
+  const [selectedLearnLanguage, setSelectedLearnLanguage] = useState<string | null>(null);
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleContinue = async () => {
+    const { data } = await supabase.auth.getSession();
+    const userId = data?.session?.user?.id;
+
+    if (userId && selectedLearnLanguage) {
+      const { error } = await supabase
+        .from("user_info")
+        .update({ learn_language: selectedLearnLanguage })
+        .eq("user_id", userId);
+
+      if (!error) {
+        router.push("/"); // 홈화면으로 이동
+      }
+    }
+  };
+
+  return (
+    <div>
+      <h2>Select the Language You Want to Learn</h2>
+      <div>
+        {learnLanguages.map((language) => (
+          <button
+            key={language}
+            onClick={() => setSelectedLearnLanguage(language)}
+            className={`p-2 m-2 rounded ${selectedLearnLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
+          >
+            {language}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={handleContinue}
+        disabled={!selectedLearnLanguage}
+        className={`mt-4 p-2 rounded ${selectedLearnLanguage ? "bg-green-500" : "bg-gray-300"}`}
+      >
+        계속
+      </button>
+    </div>
+  );
+}

--- a/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useState } from "react";
-import { useRouter } from "next/router";
-import { createClient } from "@/utils/supabase/server";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
 
 const learnLanguages = ["영어", "일본어", "스페인어", "프랑스어"];
 

--- a/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
@@ -3,13 +3,30 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/utils/supabase/client";
+import { useQuery } from "@tanstack/react-query";
+import { fetchLanguageName } from "@/api/firstSetting/fetchLanguageName";
 
 const learnLanguages = ["영어", "일본어", "스페인어", "프랑스어"];
 
 export default function SetLearnLanguage() {
-  const [selectedLearnLanguage, setSelectedLearnLanguage] = useState<string | null>(null);
+  const [selectedLearnLanguage, setSelectedLearnLanguage] = useState<string>("");
   const router = useRouter();
   const supabase = createClient();
+
+  // Tanstack Query - 지원언어 데이터 가져오기
+  const {
+    data: languages,
+    error: languagesError,
+    isLoading: languagesLoading
+  } = useQuery({
+    queryKey: ["language"],
+    queryFn: () => fetchLanguageName()
+  });
+
+  // 로딩 상태
+  if (languagesLoading) return <p>Loading...</p>;
+  // 오류 상태
+  if (languagesError) return <p>Error loading user answers: {languagesError.message}</p>;
 
   const handleContinue = async () => {
     const { data } = await supabase.auth.getSession();
@@ -22,7 +39,7 @@ export default function SetLearnLanguage() {
       const { error } = await supabase
         .from("user_info")
         .update({ learn_language: selectedLearnLanguage })
-        .eq("user_id", userId);
+        .eq("id", userId);
 
       if (!error) {
         router.push("/"); // 홈화면으로 이동
@@ -35,13 +52,15 @@ export default function SetLearnLanguage() {
       <h1>너의 학습언어 알려줘</h1>
       <p>본인이 배우고 싶은 언어를 설정해주시면 됩니다.</p>
       <div className="flex flex-col justify-center items-center">
-        {learnLanguages.map((language) => (
+        {languages?.map((language, index) => (
           <button
-            key={language}
-            onClick={() => setSelectedLearnLanguage(language)}
-            className={`w-[50%] p-2 m-2 rounded ${selectedLearnLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
+            key={index}
+            onClick={() => setSelectedLearnLanguage(language.language_name)}
+            className={`w-[50%] p-2 m-2 rounded ${
+              selectedLearnLanguage === language.language_name ? "bg-green-500" : "bg-gray-300"
+            }`}
           >
-            {language}
+            {language.language_name}
           </button>
         ))}
       </div>

--- a/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setLearnLanguage/page.tsx
@@ -15,6 +15,9 @@ export default function SetLearnLanguage() {
     const { data } = await supabase.auth.getSession();
     const userId = data?.session?.user?.id;
 
+    console.log("User ID:", userId); // 유저 ID 확인
+    console.log("learnLanguage to update:", selectedLearnLanguage); // 업데이트할 닉네임 확인
+
     if (userId && selectedLearnLanguage) {
       const { error } = await supabase
         .from("user_info")
@@ -29,13 +32,14 @@ export default function SetLearnLanguage() {
 
   return (
     <div>
-      <h2>Select the Language You Want to Learn</h2>
-      <div>
+      <h1>너의 학습언어 알려줘</h1>
+      <p>본인이 배우고 싶은 언어를 설정해주시면 됩니다.</p>
+      <div className="flex flex-col justify-center items-center">
         {learnLanguages.map((language) => (
           <button
             key={language}
             onClick={() => setSelectedLearnLanguage(language)}
-            className={`p-2 m-2 rounded ${selectedLearnLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
+            className={`w-[50%] p-2 m-2 rounded ${selectedLearnLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
           >
             {language}
           </button>
@@ -44,7 +48,7 @@ export default function SetLearnLanguage() {
       <button
         onClick={handleContinue}
         disabled={!selectedLearnLanguage}
-        className={`mt-4 p-2 rounded ${selectedLearnLanguage ? "bg-green-500" : "bg-gray-300"}`}
+        className={`w-full mt-4 p-2 rounded ${selectedLearnLanguage ? "bg-green-500" : "bg-gray-300"}`}
       >
         계속
       </button>

--- a/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { createClient } from "@/utils/supabase/server";
+
+const languages = ["한국어", "일본어", "스페인어", "영어"];
+
+export default function SetMyLanguage() {
+  const [selectedMyLanguage, setSelectedMyLanguage] = useState<string | null>(null);
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleContinue = async () => {
+    const { data } = await supabase.auth.getSession();
+    const userId = data?.session?.user?.id;
+
+    if (userId && selectedMyLanguage) {
+      const { error } = await supabase
+        .from("user_info")
+        .update({ my_language: selectedMyLanguage })
+        .eq("user_id", userId);
+
+      if (!error) {
+        router.push("/loginInfo/setLearnLanguage");
+      }
+    }
+  };
+
+  return (
+    <div>
+      <h2>Select Your Native Language</h2>
+      <div>
+        {languages.map((language) => (
+          <button
+            key={language}
+            onClick={() => setSelectedMyLanguage(language)}
+            className={`p-2 m-2 rounded ${selectedMyLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
+          >
+            {language}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={handleContinue}
+        disabled={!selectedMyLanguage}
+        className={`mt-4 p-2 rounded ${selectedMyLanguage ? "bg-green-500" : "bg-gray-300"}`}
+      >
+        계속
+      </button>
+    </div>
+  );
+}

--- a/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
@@ -3,13 +3,28 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/utils/supabase/client";
-
-const languages = ["한국어", "일본어", "스페인어", "영어"];
+import { useQuery } from "@tanstack/react-query";
+import { fetchLanguageName } from "@/api/firstSetting/fetchLanguageName";
 
 export default function SetMyLanguage() {
-  const [selectedMyLanguage, setSelectedMyLanguage] = useState<string | null>(null);
+  const [selectedMyLanguage, setSelectedMyLanguage] = useState<string>("");
   const router = useRouter();
   const supabase = createClient();
+
+  // Tanstack Query - 지원언어 데이터 가져오기
+  const {
+    data: languages,
+    error: languagesError,
+    isLoading: languagesLoading
+  } = useQuery({
+    queryKey: ["language"],
+    queryFn: () => fetchLanguageName()
+  });
+
+  // 로딩 상태
+  if (languagesLoading) return <p>Loading...</p>;
+  // 오류 상태
+  if (languagesError) return <p>Error loading user answers: {languagesError.message}</p>;
 
   const handleContinue = async () => {
     const { data } = await supabase.auth.getSession();
@@ -19,10 +34,7 @@ export default function SetMyLanguage() {
     console.log("mylanguage to update:", selectedMyLanguage); // 업데이트할 닉네임 확인
 
     if (userId && selectedMyLanguage) {
-      const { error } = await supabase
-        .from("user_info")
-        .update({ my_language: selectedMyLanguage })
-        .eq("user_id", userId);
+      const { error } = await supabase.from("user_info").update({ my_language: selectedMyLanguage }).eq("id", userId);
 
       if (!error) {
         router.push("/loginInfo/setLearnLanguage");
@@ -35,13 +47,15 @@ export default function SetMyLanguage() {
       <h1>너의 모국어 알려줘</h1>
       <p>본인의 모국어를 설정해주시면 됩니다.</p>
       <div className="flex flex-col justify-center items-center">
-        {languages.map((language) => (
+        {languages?.map((language, index) => (
           <button
-            key={language}
-            onClick={() => setSelectedMyLanguage(language)}
-            className={`w-[50%] p-2 m-2 rounded ${selectedMyLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
+            key={index}
+            onClick={() => setSelectedMyLanguage(language.language_name)}
+            className={`w-[50%] p-2 m-2 rounded ${
+              selectedMyLanguage === language.language_name ? "bg-green-500" : "bg-gray-300"
+            }`}
           >
-            {language}
+            {language.language_name}
           </button>
         ))}
       </div>

--- a/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { useState } from "react";
-import { useRouter } from "next/router";
+import { useRouter } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
 
 const languages = ["한국어", "일본어", "스페인어", "영어"];

--- a/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
+++ b/src/app/(mobile)/loginInfo/setMyLanguage/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClient } from "@/utils/supabase/server";
+import { createClient } from "@/utils/supabase/client";
 
 const languages = ["한국어", "일본어", "스페인어", "영어"];
 
@@ -14,6 +14,9 @@ export default function SetMyLanguage() {
   const handleContinue = async () => {
     const { data } = await supabase.auth.getSession();
     const userId = data?.session?.user?.id;
+
+    console.log("User ID:", userId); // 유저 ID 확인
+    console.log("mylanguage to update:", selectedMyLanguage); // 업데이트할 닉네임 확인
 
     if (userId && selectedMyLanguage) {
       const { error } = await supabase
@@ -29,13 +32,14 @@ export default function SetMyLanguage() {
 
   return (
     <div>
-      <h2>Select Your Native Language</h2>
-      <div>
+      <h1>너의 모국어 알려줘</h1>
+      <p>본인의 모국어를 설정해주시면 됩니다.</p>
+      <div className="flex flex-col justify-center items-center">
         {languages.map((language) => (
           <button
             key={language}
             onClick={() => setSelectedMyLanguage(language)}
-            className={`p-2 m-2 rounded ${selectedMyLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
+            className={`w-[50%] p-2 m-2 rounded ${selectedMyLanguage === language ? "bg-green-500" : "bg-gray-300"}`}
           >
             {language}
           </button>
@@ -44,7 +48,7 @@ export default function SetMyLanguage() {
       <button
         onClick={handleContinue}
         disabled={!selectedMyLanguage}
-        className={`mt-4 p-2 rounded ${selectedMyLanguage ? "bg-green-500" : "bg-gray-300"}`}
+        className={`w-full mt-4 p-2 rounded ${selectedMyLanguage ? "bg-green-500" : "bg-gray-300"}`}
       >
         계속
       </button>

--- a/src/app/(mobile)/loginInfo/setNickname/page.tsx
+++ b/src/app/(mobile)/loginInfo/setNickname/page.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useState } from "react";
-import { useRouter } from "next/router";
-import { createClient } from "@/utils/supabase/server";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
 
 export default function SetNickname() {
   const [nickname, setNickname] = useState("");

--- a/src/app/(mobile)/loginInfo/setNickname/page.tsx
+++ b/src/app/(mobile)/loginInfo/setNickname/page.tsx
@@ -18,7 +18,7 @@ export default function SetNickname() {
       console.log("Nickname to update:", nickname); // 업데이트할 닉네임 확인
 
       if (userId) {
-        const { error } = await supabase.from("user_info").update({ nickname }).eq("user_id", userId);
+        const { error } = await supabase.from("user_info").update({ nickname }).eq("id", userId);
 
         if (!error) {
           router.push("/loginInfo/setMyLanguage");

--- a/src/app/(mobile)/loginInfo/setNickname/page.tsx
+++ b/src/app/(mobile)/loginInfo/setNickname/page.tsx
@@ -14,6 +14,9 @@ export default function SetNickname() {
       const { data } = await supabase.auth.getSession();
       const userId = data?.session?.user?.id;
 
+      console.log("User ID:", userId); // 유저 ID 확인
+      console.log("Nickname to update:", nickname); // 업데이트할 닉네임 확인
+
       if (userId) {
         const { error } = await supabase.from("user_info").update({ nickname }).eq("user_id", userId);
 
@@ -26,18 +29,23 @@ export default function SetNickname() {
 
   return (
     <div>
-      <h2>Set your Nickname</h2>
-      <input
-        type="text"
-        value={nickname}
-        onChange={(e) => setNickname(e.target.value)}
-        placeholder="Enter nickname"
-        className="border rounded p-2"
-      />
+      <h1>닉네임 알려줘</h1>
+      <p>원픽에서 사용할 닉네임을 설정해 주시면 됩니다.</p>
+      <div className="flex flex-col">
+        <label>닉네임</label>
+        <input
+          type="text"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder="닉네임을 작성해주세요"
+          className="border rounded p-2"
+        />
+        <p>최대 12글자</p>
+      </div>
       <button
         onClick={handleContinue}
         disabled={!nickname}
-        className={`mt-4 p-2 rounded ${nickname ? "bg-green-500" : "bg-gray-300"}`}
+        className={`w-full mt-4 p-2 rounded ${nickname ? "bg-green-500" : "bg-gray-300"}`}
       >
         계속
       </button>

--- a/src/app/(mobile)/loginInfo/setNickname/page.tsx
+++ b/src/app/(mobile)/loginInfo/setNickname/page.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { createClient } from "@/utils/supabase/server";
+
+export default function SetNickname() {
+  const [nickname, setNickname] = useState("");
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleContinue = async () => {
+    if (nickname) {
+      const { data } = await supabase.auth.getSession();
+      const userId = data?.session?.user?.id;
+
+      if (userId) {
+        const { error } = await supabase.from("user_info").update({ nickname }).eq("user_id", userId);
+
+        if (!error) {
+          router.push("/loginInfo/setMyLanguage");
+        }
+      }
+    }
+  };
+
+  return (
+    <div>
+      <h2>Set your Nickname</h2>
+      <input
+        type="text"
+        value={nickname}
+        onChange={(e) => setNickname(e.target.value)}
+        placeholder="Enter nickname"
+        className="border rounded p-2"
+      />
+      <button
+        onClick={handleContinue}
+        disabled={!nickname}
+        className={`mt-4 p-2 rounded ${nickname ? "bg-green-500" : "bg-gray-300"}`}
+      >
+        계속
+      </button>
+    </div>
+  );
+}

--- a/src/app/(mobile)/page.tsx
+++ b/src/app/(mobile)/page.tsx
@@ -1,31 +1,45 @@
 "use client";
+
 import BottomSheetModal from "@/components/BottomSheetModal";
 import CustomizedLearn from "@/components/chatBot/aiTutorHome/CustomizedLearn";
 import Reviewing from "@/components/chatBot/aiTutorHome/Reviewing";
 import TodayLearn from "@/components/chatBot/aiTutorHome/TodayLearn";
 import { createClient } from "@/utils/supabase/client";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 export default function Home() {
-  // 로그인 상태를 저장
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  // 모달 표시 여부
-  const [showModal, setShowModal] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태를 저장
+  const [showModal, setShowModal] = useState(false); // 모달 표시 여부
+  const router = useRouter();
 
   useEffect(() => {
     // 로그인 상태를 확인하는 비동기 함수
     const checkLoginStatus = async () => {
       const supabase = createClient();
       const { data } = await supabase.auth.getSession();
+
       if (data.session) {
         setIsLoggedIn(true); // 세션이 있으면 로그인 상태로 설정
+
+        // 로그인 후 user_info 테이블을 확인
+        const { data: userInfo } = await supabase
+          .from("user_info")
+          .select("nickname, my_language, learn_language")
+          .eq("user_id", data.session.user.id)
+          .single();
+
+        // userInfo가 null인지 확인한 후, 초기 정보가 없을 경우 설정 페이지로 이동
+        if (userInfo && !userInfo.nickname && !userInfo.my_language && !userInfo.learn_language) {
+          router.push("/loginInfo/setNickname");
+        }
       } else {
         setShowModal(true); // 세션이 없으면 모달을 표시
       }
     };
 
     checkLoginStatus();
-  }, []);
+  }, [router]);
 
   return (
     <div className="w-full h-[1000px] bg-gray-100 p-5">

--- a/src/app/(mobile)/page.tsx
+++ b/src/app/(mobile)/page.tsx
@@ -1,14 +1,43 @@
+"use client";
+import BottomSheetModal from "@/components/BottomSheetModal";
 import CustomizedLearn from "@/components/chatBot/aiTutorHome/CustomizedLearn";
 import Reviewing from "@/components/chatBot/aiTutorHome/Reviewing";
 import TodayLearn from "@/components/chatBot/aiTutorHome/TodayLearn";
+import { createClient } from "@/utils/supabase/client";
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  // 로그인 상태를 저장
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  // 모달 표시 여부
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    // 로그인 상태를 확인하는 비동기 함수
+    const checkLoginStatus = async () => {
+      const supabase = createClient();
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        setIsLoggedIn(true); // 세션이 있으면 로그인 상태로 설정
+      } else {
+        setShowModal(true); // 세션이 없으면 모달을 표시
+      }
+    };
+
+    checkLoginStatus();
+  }, []);
+
   return (
     <div className="w-full h-[1000px] bg-gray-100 p-5">
-      <div className="h-10"></div>
-      <TodayLearn />
-      <CustomizedLearn />
-      <Reviewing />
+      {showModal && <BottomSheetModal onClose={() => setShowModal(false)} />}
+      {isLoggedIn && (
+        <>
+          <div className="h-10"></div>
+          <TodayLearn />
+          <CustomizedLearn />
+          <Reviewing />
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(mobile)/page.tsx
+++ b/src/app/(mobile)/page.tsx
@@ -30,9 +30,10 @@ export default function Home() {
           .single();
 
         // userInfo가 null인지 확인한 후, 초기 정보가 없을 경우 설정 페이지로 이동
-        if (userInfo && !userInfo.nickname && !userInfo.my_language && !userInfo.learn_language) {
+        if (!userInfo || !userInfo.nickname || !userInfo.my_language || !userInfo.learn_language) {
           router.push("/loginInfo/setNickname");
         }
+        console.log("userInfo", userInfo);
       } else {
         setShowModal(true); // 세션이 없으면 모달을 표시
       }

--- a/src/app/(mobile)/page.tsx
+++ b/src/app/(mobile)/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
         const { data: userInfo } = await supabase
           .from("user_info")
           .select("nickname, my_language, learn_language")
-          .eq("user_id", data.session.user.id)
+          .eq("id", data.session.user.id)
           .single();
 
         // userInfo가 null인지 확인한 후, 초기 정보가 없을 경우 설정 페이지로 이동

--- a/src/app/(mobile)/page.tsx
+++ b/src/app/(mobile)/page.tsx
@@ -5,7 +5,7 @@ import CustomizedLearn from "@/components/chatBot/aiTutorHome/CustomizedLearn";
 import Reviewing from "@/components/chatBot/aiTutorHome/Reviewing";
 import TodayLearn from "@/components/chatBot/aiTutorHome/TodayLearn";
 import { createClient } from "@/utils/supabase/client";
-import { useRouter } from "next/router";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function Home() {

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,0 +1,28 @@
+import { signInWithProvider } from "@/app/services/supabaseAuth";
+import React from "react";
+
+const BottomSheetModal = () => {
+  const handleSignInWithGoogle = async () => {
+    await signInWithProvider("google");
+  };
+
+  return (
+    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex justify-center items-end z-50">
+      <div className="bg-white w-full max-w-md p-6 rounded-t-lg">
+        {/* <button onClick={onClose} className="text-gray-500 float-right">
+          닫기
+        </button> */}
+        <h2 className="text-xl font-bold mb-4">로그인이 필요합니다</h2>
+        <p className="mb-4">서비스를 이용하려면 로그인이 필요합니다.</p>
+        <button onClick={handleSignInWithGoogle} className="w-full bg-blue-500 text-white py-2 rounded">
+          구글
+        </button>
+        <button type="button">카카오</button>
+        <button type="button">네이버</button>
+        <button type="button">애플</button>
+      </div>
+    </div>
+  );
+};
+
+export default BottomSheetModal;

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -12,14 +12,10 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-12 bg-gray-500 bg-opacity-75 flex justify-center items-end z-20">
-      <div className="bg-white w-full max-w-md p-6 rounded-t-lg">
-        <button onClick={onClose} className="text-gray-500 float-right">
-          닫기
-        </button>
-        <h2 className="text-xl font-bold mb-4">로그인이 필요합니다</h2>
-        <p className="mb-4">서비스를 이용하려면 로그인이 필요합니다.</p>
-        <div className="flex gap-4">
+    <div className="fixed inset-12 bg-gray-500 bg-opacity-75 flex justify-center items-end z-1">
+      <div className="bg-white w-full max-w-md p-6 rounded-t-lg flex flex-col items-center">
+        <h2 className="text-xl font-bold mb-4">SNS 로그인</h2>
+        <div className="flex gap-10">
           <button onClick={handleSignInWithGoogle} className=" bg-blue-500 text-white py-2 rounded">
             구글
           </button>

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -12,19 +12,27 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex justify-center items-end z-50">
+    <div className="fixed inset-12 bg-gray-500 bg-opacity-75 flex justify-center items-end z-20">
       <div className="bg-white w-full max-w-md p-6 rounded-t-lg">
         <button onClick={onClose} className="text-gray-500 float-right">
           닫기
         </button>
         <h2 className="text-xl font-bold mb-4">로그인이 필요합니다</h2>
         <p className="mb-4">서비스를 이용하려면 로그인이 필요합니다.</p>
-        <button onClick={handleSignInWithGoogle} className="w-full bg-blue-500 text-white py-2 rounded">
-          구글
-        </button>
-        <button type="button">카카오</button>
-        <button type="button">네이버</button>
-        <button type="button">애플</button>
+        <div className="flex gap-4">
+          <button onClick={handleSignInWithGoogle} className=" bg-blue-500 text-white py-2 rounded">
+            구글
+          </button>
+          <button type="button" className=" bg-blue-500 text-white py-2 rounded">
+            카카오
+          </button>
+          <button type="button" className=" bg-blue-500 text-white py-2 rounded">
+            네이버
+          </button>
+          <button type="button" className=" bg-blue-500 text-white py-2 rounded">
+            애플
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,7 +1,12 @@
 import { signInWithProvider } from "@/app/services/supabaseAuth";
 import React from "react";
 
-const BottomSheetModal = () => {
+// 모달을 닫기 위한 콜백 함수 타입 정의
+interface BottomSheetModalProps {
+  onClose: () => void;
+}
+
+const BottomSheetModal: React.FC<BottomSheetModalProps> = ({ onClose }) => {
   const handleSignInWithGoogle = async () => {
     await signInWithProvider("google");
   };
@@ -9,9 +14,9 @@ const BottomSheetModal = () => {
   return (
     <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex justify-center items-end z-50">
       <div className="bg-white w-full max-w-md p-6 rounded-t-lg">
-        {/* <button onClick={onClose} className="text-gray-500 float-right">
+        <button onClick={onClose} className="text-gray-500 float-right">
           닫기
-        </button> */}
+        </button>
         <h2 className="text-xl font-bold mb-4">로그인이 필요합니다</h2>
         <p className="mb-4">서비스를 이용하려면 로그인이 필요합니다.</p>
         <button onClick={handleSignInWithGoogle} className="w-full bg-blue-500 text-white py-2 rounded">


### PR DESCRIPTION
## 🔥 작업 내용

- 로그인 바텀시트 모달
- 첫 로그인 시, 닉네임/모국어/학습언어 초기설정 페이지로 이동

## 👍 참고 사항

- 홈 페이지를 클라이언트 컴포넌트("use client";)로 변경(←useState, useEffect 사용)
- 바텀시트 모달 나타났을 때 스크림 부분이 화면 전체에 적용되는 부분 해결 못함.(style이라 추후 수정예정)
- supabase - user_info 테이블의 nickname, my_language, learn_language를 `allow nullable` 설정을 켜서 타입오류가 생겼을 수 있으니 해당 데이터 사용하시는 분들 코드 확인 부탁드립니다.(타입 업데이트 필요)
