### PR TITLE
Style/chatbot

### DIFF
--- a/src/components/chatBot/aiTutorHome/TodayLearn.tsx
+++ b/src/components/chatBot/aiTutorHome/TodayLearn.tsx
@@ -3,10 +3,13 @@
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { reviewApi } from "@/services/supabaseChatbot";
-import Slider from "react-slick";
+// import Slider from "react-slick";
+import dynamic from "next/dynamic";
 import star from "@/assets/star.svg";
 import Image from "next/image";
 import { Typography } from "@/components/ui/typography";
+
+const Slider = dynamic(() => import("react-slick"), { ssr: false });
 
 const TodayLearn = () => {
   const router = useRouter();
@@ -42,7 +45,7 @@ const TodayLearn = () => {
         }
       },
       {
-        breakpoint: 9999, // PC
+        breakpoint: 5000, // PC
         settings: {
           slidesToShow: 3,
           slidesToScroll: 1,
@@ -62,7 +65,7 @@ const TodayLearn = () => {
           매일 업데이트 되는 추천 학습
         </Typography>
       </div>
-      <Slider {...settings} className="[&_.slick-slide]:px-2 [&_.slick-track]:gap-4">
+      <Slider {...settings} className="[&_.slick-slide]:px-2 md:[&_.slick-track]:!translate-x-0 [&_.slick-track]:gap-4">
         {situations?.map((situation) => (
           <div key={situation.id} onClick={(e) => handleLearnSelect(e, situation.situation, situation.level)}>
             <div


### PR DESCRIPTION
## 🔥 작업 내용

- 테블릿, PC 사이즈일 경우 첫 렌더링 시 이미지 캐러셀 오른쪽으로 밀려나있는 버그 수정하였습니다!
- 캐러셀 자체에서 translate 값이 1026px이 들어가 있어서 Silder 태그에 아래의 코드를 추가하여 translate를 강제로 제어하는 방법으로 해결했습니다
```js
md:[&_.slick-track]:!translate-x-0
```



## 📸 빌드 캡쳐 내역
![image](https://github.com/user-attachments/assets/23e92809-0fce-42ba-8b06-73c99e2e862f)

