### PR TITLE
Style/login

### DIFF
--- a/src/app/(mobile)/challenge/word/(quiz)/english/page.tsx
+++ b/src/app/(mobile)/challenge/word/(quiz)/english/page.tsx
@@ -23,7 +23,7 @@ const EnglishWordQuiz = () => {
 
   return (
     <div className="flex flex-col gap-[70px]">
-      {isLargeScreen && <WithIconHeader title="문법 챌린지" />}
+      {isLargeScreen && <WithIconHeader title="단어 챌린지" />}
       <RandomEnglishWordQuiz userId={userId} />
     </div>
   );

--- a/src/app/(mobile)/challenge/word/(quiz)/korean/page.tsx
+++ b/src/app/(mobile)/challenge/word/(quiz)/korean/page.tsx
@@ -23,7 +23,7 @@ const KoreanWordQuiz = () => {
 
   return (
     <div className="flex flex-col gap-[70px]">
-      {isLargeScreen && <WithIconHeader title="문법 챌린지" />}
+      {isLargeScreen && <WithIconHeader title="단어 챌린지" />}
       <RandomKoreanWordQuiz userId={userId} />
     </div>
   );

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,9 +1,10 @@
 import { signInWithProvider } from "@/services/supabaseAuth";
-import React from "react";
+import React, { useState } from "react";
 import naver from "@/assets/rectangle-120.svg";
 import kakao from "@/assets/rectangle-123.svg";
 import google from "@/assets/rectangle-125.svg";
 import Image from "next/image";
+import ChatModal from "./ChatModal";
 
 // 모달을 닫기 위한 콜백 함수 타입 정의
 interface BottomSheetModalProps {
@@ -12,10 +13,15 @@ interface BottomSheetModalProps {
 
 const BottomSheetModal: React.FC<BottomSheetModalProps> = ({ onClose }) => {
   const handleSignInWithGoogle = async () => {
-    console.log("zz ??");
     await signInWithProvider("google");
   };
   console.log(onClose); // build 오류 임시 해결
+
+  // 오픈 예정 알림 모달
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
 
   return (
     <div className="flex flex-col mt-[30px] md:my-[58px] gap-[40px] justify-center items-center">
@@ -24,10 +30,23 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({ onClose }) => {
         <button onClick={handleSignInWithGoogle}>
           <Image src={google} alt="Rectangle125" className="cursor-pointer" />
         </button>
-
-        <Image src={kakao} alt="Rectangle123" />
-        <Image src={naver} alt="Rectangle120" />
+        <button onClick={openModal}>
+          <Image src={kakao} alt="Rectangle123" />
+        </button>
+        <button onClick={openModal}>
+          <Image src={naver} alt="Rectangle120" />
+        </button>
       </div>
+      <ChatModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={() => setIsModalOpen(false)}
+        title="알림"
+        description="오픈 예정입니다"
+        confirmText="확인"
+        confirmButtonStyle="primary"
+        showCancel={false}
+      />
     </div>
   );
 };

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -49,7 +49,7 @@ const ChatModal = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-50">
+    <div className="fixed inset-0 flex items-center justify-center z-[250]">
       {/* 배경 오버레이 */}
       <div className="fixed inset-0 bg-black bg-opacity-30" onClick={onClose} aria-hidden="true" />
 


### PR DESCRIPTION
## 🔥 작업 내용

- 홈화면 `ChatModal.tsx` 띄웠을 때 PC버전 `HeaderTop.tsx`의 z-index가 더 높아 홈헤더도 가리게 수정했습니다.
- PC 버전에서 '`단어`챌린지 풀러가기' 클릭했을 때 페이지 헤더가 `문법챌린지`로 되어있는 것 발견하여 수정했습니다.
- UT 테스트 결과로, 로그인 시 카카오톡/네이버 클릭 시 '오픈예정' 알림모달 띄우는 것으로 반영했습니다.

## 👍 참고 사항
- 두 번째 작업내용은 어느 분 작업인지 몰라 예상 되는 서연님, 민정님 모두 리뷰어로 지정했습니다.

## 📸 빌드 캡쳐 내역
<img width="491" alt="image" src="https://github.com/user-attachments/assets/5483c78c-d646-4b4a-b431-08e9f1393d52">
